### PR TITLE
Fixed the Image Problem

### DIFF
--- a/src/data/educationMedia.ts
+++ b/src/data/educationMedia.ts
@@ -1,18 +1,32 @@
+// Import all education images
+import image1 from "../assets/education/images/1.jpeg";
+import image2 from "../assets/education/images/2.jpeg";
+import image3 from "../assets/education/images/3.jpeg";
+import image4 from "../assets/education/images/4.jpeg";
+import image5 from "../assets/education/images/5.jpeg";
+import image6 from "../assets/education/images/6.jpeg";
+
+// Import all education videos and thumbnails
+import video1 from "../assets/education/videos/1st.mp4";
+import video1Thumbnail from "../assets/education/videos/1st.png";
+import video2 from "../assets/education/videos/2nd.mp4";
+import video2Thumbnail from "../assets/education/videos/2nd.jpeg";
+
 export const educationMediaConfig = {
   videos: [
     {
       id: 1,
       title: "Analyzing Students with personal PI's and tests",
-      thumbnail: "src/assets/education/videos/1st.png",
-      videoUrl: "src/assets/education/videos/1st.mp4",
+      thumbnail: video1Thumbnail,
+      videoUrl: video1,
       description:
         "Learn how our comprehensive approach to analyzing students through personalized assessments and testing methodologies enhances learning outcomes and academic success.",
     },
     {
       id: 2,
       title: "University Partnership Program",
-      thumbnail: "src/assets/education/videos/2nd.jpeg",
-      videoUrl: "src/assets/education/videos/2nd.mp4",
+      thumbnail: video2Thumbnail,
+      videoUrl: video2,
       description:
         "Our successful collaboration with leading universities to enhance curriculum and student outcomes.",
     },
@@ -22,42 +36,42 @@ export const educationMediaConfig = {
     {
       id: 1,
       title: "Interactive Training Session",
-      url: "src/assets/education/images/1.jpeg",
+      url: image1,
       description:
         "Students engaged in hands-on learning with modern technology and expert guidance.",
     },
     {
       id: 2,
       title: "Student Development Classes",
-      url: "src/assets/education/images/2.jpeg",
+      url: image2,
       description:
         "Comprehensive student development programs focusing on personal growth, professional skills, and career readiness through structured learning modules.",
     },
     {
       id: 3,
       title: "Hands-on Practices",
-      url: "src/assets/education/images/3.jpeg",
+      url: image3,
       description:
         "Interactive practical sessions where students apply theoretical knowledge through real-world exercises and skill-building activities.",
     },
     {
       id: 4,
       title: "Industry Expert Session",
-      url: "src/assets/education/images/4.jpeg",
+      url: image4,
       description:
         "Guest lecture by industry professionals sharing real-world insights.",
     },
     {
       id: 5,
       title: "Exam Time",
-      url: "src/assets/education/images/5.jpeg",
+      url: image5,
       description:
-        "Students demonstrating their knowledge and skills through comprehensive assessments and evaluation processes."
+        "Students demonstrating their knowledge and skills through comprehensive assessments and evaluation processes.",
     },
     {
       id: 6,
       title: "Hands-on Lab Session",
-      url: "src/assets/education/images/6.jpeg",
+      url: image6,
       description:
         "Practical learning experience in our state-of-the-art laboratory facilities.",
     },


### PR DESCRIPTION
This pull request updates the way education media assets (images and videos) are imported and referenced in the `educationMediaConfig` object. Instead of using string paths, the assets are now imported as modules and referenced directly, which improves reliability and maintainability.

**Media asset import and usage improvements:**

* All education images (`1.jpeg` to `6.jpeg`) are now imported at the top of `src/data/educationMedia.ts` and referenced directly in the `images` array via their respective variables, replacing previous string paths. [[1]](diffhunk://#diff-6710be8fb536d3c53397168d017313b78310ad794eaa689d20d32d4e49d188d3R1-R29) [[2]](diffhunk://#diff-6710be8fb536d3c53397168d017313b78310ad794eaa689d20d32d4e49d188d3L25-R74)
* All education videos (`1st.mp4`, `2nd.mp4`) and their thumbnails are now imported as modules and referenced directly in the `videos` array, replacing previous string paths for `thumbnail` and `videoUrl`.